### PR TITLE
Replace project selection with folder selection.

### DIFF
--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.java
@@ -24,7 +24,7 @@ public class AngularCLIMessages extends NLS {
 	private static final String BUNDLE_NAME = "ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages"; //$NON-NLS-1$
 
 	private static ResourceBundle fResourceBundle;
-	
+
 	// Preferences
 	public static String AngularCLIConfigurationBlock_cli_group_label;
 	public static String AngularCLIConfigurationBlock_ngUseGlobalInstallation_label;
@@ -55,11 +55,14 @@ public class AngularCLIMessages extends NLS {
 	public static String NewAngular2ProjectParamsWizardPage_inline;
 	public static String NewAngular2ProjectParamsWizardPage_inlineStyle;
 	public static String NewAngular2ProjectParamsWizardPage_inlineTemplate;
-	
-	public static String NgGenerateBlueprintWizardPage_projectName;
+
+	public static String NgGenerateBlueprintWizardPage_location;
+	public static String NgGenerateBlueprintWizardPage_browse_location;
+	public static String NgGenerateBlueprintWizardPage_browse_location_title;
+	public static String NgGenerateBlueprintWizardPage_browse_location_message;
 	public static String NgGenerateBlueprintWizardPage_bluePrintName;
-	public static String NgGenerateBlueprintWizardPage_select_ngProject_error;
 	public static String NgGenerateBlueprintWizardPage_select_name_required_error;
+	public static String NgGenerateBlueprintWizardPage_invalid_location_error;
 
 	public static String NewNgModuleWizard_windowTitle;
 	public static String NewNgModuleWizardPage_title;
@@ -93,7 +96,7 @@ public class AngularCLIMessages extends NLS {
 	public static String AngularCLIEditor_OverviewPage_GeneralInformationSection_desc;
 	public static String AngularCLIEditor_OverviewPage_projectName_label;
 	public static String AngularCLIEditor_OverviewPage_projectVersion_label;
-	
+
 	public static String AngularCLIEditor_NgServeAction_text;
 	public static String AngularCLIEditor_NgBuildAction_text;
 	public static String AngularCLIEditor_NgTestAction_text;

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.properties
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.properties
@@ -6,7 +6,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#     Angelo Zerr <angelo.zerr@gmail.com> - Initial API and implementation 
+#     Angelo Zerr <angelo.zerr@gmail.com> - Initial API and implementation
 ###############################################################################
 
 # Preferences
@@ -43,10 +43,13 @@ NewAngular2ProjectParamsWizardPage_routing=&Routing:
 NewAngular2ProjectParamsWizardPage_inline=&Inline:
 NewAngular2ProjectParamsWizardPage_inlineStyle=Style
 NewAngular2ProjectParamsWizardPage_inlineTemplate=Template
-NgGenerateBlueprintWizardPage_projectName=&Project:
+NgGenerateBlueprintWizardPage_location=&Location:
+NgGenerateBlueprintWizardPage_browse_location=&Browse...
+NgGenerateBlueprintWizardPage_browse_location_title=Select folder:
+NgGenerateBlueprintWizardPage_browse_location_message=Select a folder:
 NgGenerateBlueprintWizardPage_bluePrintName=&Name:
-NgGenerateBlueprintWizardPage_select_ngProject_error=Please select a project which was generated with angular-cli.
 NgGenerateBlueprintWizardPage_select_name_required_error=Name cannot be empty.
+NgGenerateBlueprintWizardPage_invalid_location_error=Location must be a folder.
 NewNgModuleWizard_windowTitle=New Angular2 Module
 NewNgModuleWizardPage_title=Angular2 Module
 NewNgModuleWizardPage_routing=&Routing:

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/launch/AngularCLILaunchConfigurationDelegate.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/launch/AngularCLILaunchConfigurationDelegate.java
@@ -13,6 +13,7 @@ package ts.eclipse.ide.angular2.internal.cli.launch;
 import java.io.File;
 
 import org.eclipse.core.externaltools.internal.launchConfigurations.ExternalToolsCoreUtil;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -55,7 +56,9 @@ public class AngularCLILaunchConfigurationDelegate implements ILaunchConfigurati
 		NgCommand ngCommand = NgCommand.getCommand(operation);
 		boolean waitForTerminate = isWaitForTerminate(ngCommand);
 
-		IProject project = (IProject) ResourcesPlugin.getWorkspace().getRoot().getContainerForLocation(wd);
+		IContainer folder = ResourcesPlugin.getWorkspace().getRoot().getContainerForLocation(wd);
+		IProject project = folder instanceof IProject ? (IProject)folder : folder.getProject();
+
 		CLIStreamListener listener = createListener(ngCommand, project, options);
 		try {
 			new CLI(null, wd, command).execute(listener, waitForTerminate, monitor);

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/launch/AngularCLILaunchHelper.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/launch/AngularCLILaunchHelper.java
@@ -12,6 +12,7 @@ package ts.eclipse.ide.angular2.internal.cli.launch;
 
 import java.io.File;
 
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
@@ -32,6 +33,10 @@ import ts.utils.FileUtils;
  *
  */
 public class AngularCLILaunchHelper {
+
+	public static String getWorkingDir(IContainer folder) {
+		return new StringBuilder("${workspace_loc:/").append(folder.getFullPath()).append("}").toString();
+	}
 
 	public static String getWorkingDir(IProject project) {
 		return new StringBuilder("${workspace_loc:/").append(project.getName()).append("}").toString();

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgClassWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgClassWizard.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 
@@ -27,10 +27,10 @@ public class NewNgClassWizard extends AbstractNewNgGenerateWizard {
 	}
 
 	@Override
-	protected NgGenerateBlueprintWizardPage createMainPage(IProject project) {
-		return new NewNgClassWizardPage(project);
+	protected NgGenerateBlueprintWizardPage createMainPage(IContainer folder) {
+		return new NewNgClassWizardPage(folder);
 	}
-	
+
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
 		super.init(workbench, selection);

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgClassWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgClassWizardPage.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
@@ -24,8 +24,8 @@ public class NewNgClassWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private static final String PAGE_NAME = "ngClass";
 
-	protected NewNgClassWizardPage(IProject project) {
-		super(PAGE_NAME, AngularCLIMessages.NewNgClassWizardPage_title, null, NgBlueprint.CLASS, project);
+	protected NewNgClassWizardPage(IContainer folder) {
+		super(PAGE_NAME, AngularCLIMessages.NewNgClassWizardPage_title, null, NgBlueprint.CLASS, folder);
 		super.setDescription(AngularCLIMessages.NewNgClassWizardPage_description);
 	}
 

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgComponentWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgComponentWizard.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 
@@ -27,8 +27,8 @@ public class NewNgComponentWizard extends AbstractNewNgGenerateWizard {
 	}
 
 	@Override
-	protected NgGenerateBlueprintWizardPage createMainPage(IProject project) {
-		return new NewNgComponentWizardPage(project);
+	protected NgGenerateBlueprintWizardPage createMainPage(IContainer folder) {
+		return new NewNgComponentWizardPage(folder);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgComponentWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgComponentWizardPage.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
@@ -24,8 +24,8 @@ public class NewNgComponentWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private static final String PAGE_NAME = "ngComponent";
 
-	protected NewNgComponentWizardPage(IProject project) {
-		super(PAGE_NAME, AngularCLIMessages.NewNgComponentWizardPage_title, null, NgBlueprint.COMPONENT, project);
+	protected NewNgComponentWizardPage(IContainer folder) {
+		super(PAGE_NAME, AngularCLIMessages.NewNgComponentWizardPage_title, null, NgBlueprint.COMPONENT, folder);
 		super.setDescription(AngularCLIMessages.NewNgComponentWizardPage_description);
 	}
 

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgDirectiveWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgDirectiveWizard.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 
@@ -27,8 +27,8 @@ public class NewNgDirectiveWizard extends AbstractNewNgGenerateWizard {
 	}
 
 	@Override
-	protected NgGenerateBlueprintWizardPage createMainPage(IProject project) {
-		return new NewNgDirectiveWizardPage(project);
+	protected NgGenerateBlueprintWizardPage createMainPage(IContainer folder) {
+		return new NewNgDirectiveWizardPage(folder);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgDirectiveWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgDirectiveWizardPage.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
@@ -24,8 +24,8 @@ public class NewNgDirectiveWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private static final String PAGE_NAME = "ngDirective";
 
-	protected NewNgDirectiveWizardPage(IProject project) {
-		super(PAGE_NAME, AngularCLIMessages.NewNgDirectiveWizardPage_title, null, NgBlueprint.DIRECTIVE, project);
+	protected NewNgDirectiveWizardPage(IContainer folder) {
+		super(PAGE_NAME, AngularCLIMessages.NewNgDirectiveWizardPage_title, null, NgBlueprint.DIRECTIVE, folder);
 		super.setDescription(AngularCLIMessages.NewNgDirectiveWizardPage_description);
 	}
 

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgEnumWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgEnumWizard.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 
@@ -27,8 +27,8 @@ public class NewNgEnumWizard extends AbstractNewNgGenerateWizard {
 	}
 
 	@Override
-	protected NgGenerateBlueprintWizardPage createMainPage(IProject project) {
-		return new NewNgEnumWizardPage(project);
+	protected NgGenerateBlueprintWizardPage createMainPage(IContainer folder) {
+		return new NewNgEnumWizardPage(folder);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgEnumWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgEnumWizardPage.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
@@ -24,8 +24,8 @@ public class NewNgEnumWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private static final String PAGE_NAME = "ngEnum";
 
-	protected NewNgEnumWizardPage(IProject project) {
-		super(PAGE_NAME, AngularCLIMessages.NewNgEnumWizardPage_title, null, NgBlueprint.ENUM, project);
+	protected NewNgEnumWizardPage(IContainer folder) {
+		super(PAGE_NAME, AngularCLIMessages.NewNgEnumWizardPage_title, null, NgBlueprint.ENUM, folder);
 		super.setDescription(AngularCLIMessages.NewNgEnumWizardPage_description);
 	}
 

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgInterfaceWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgInterfaceWizard.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 
@@ -27,8 +27,8 @@ public class NewNgInterfaceWizard extends AbstractNewNgGenerateWizard {
 	}
 
 	@Override
-	protected NgGenerateBlueprintWizardPage createMainPage(IProject project) {
-		return new NewNgInterfaceWizardPage(project);
+	protected NgGenerateBlueprintWizardPage createMainPage(IContainer folder) {
+		return new NewNgInterfaceWizardPage(folder);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgInterfaceWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgInterfaceWizardPage.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
@@ -24,8 +24,8 @@ public class NewNgInterfaceWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private static final String PAGE_NAME = "ngInterface";
 
-	protected NewNgInterfaceWizardPage(IProject project) {
-		super(PAGE_NAME, AngularCLIMessages.NewNgInterfaceWizardPage_title, null, NgBlueprint.INTERFACE, project);
+	protected NewNgInterfaceWizardPage(IContainer folder) {
+		super(PAGE_NAME, AngularCLIMessages.NewNgInterfaceWizardPage_title, null, NgBlueprint.INTERFACE, folder);
 		super.setDescription(AngularCLIMessages.NewNgInterfaceWizardPage_description);
 	}
 

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgModuleWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgModuleWizard.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Springrbua - initial implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 
@@ -27,8 +27,8 @@ public class NewNgModuleWizard extends AbstractNewNgGenerateWizard {
 	}
 
 	@Override
-	protected NgGenerateBlueprintWizardPage createMainPage(IProject project) {
-		return new NewNgModuleWizardPage(project);
+	protected NgGenerateBlueprintWizardPage createMainPage(IContainer folder) {
+		return new NewNgModuleWizardPage(folder);
 	}
 
 	@Override
@@ -36,7 +36,7 @@ public class NewNgModuleWizard extends AbstractNewNgGenerateWizard {
 		super.init(workbench, selection);
 		super.setWindowTitle(AngularCLIMessages.NewNgModuleWizard_windowTitle);
 	}
-	
+
 	@Override
 	protected void appendOperationParameters(StringBuilder sb) {
 		super.appendOperationParameters(sb);

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgModuleWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgModuleWizardPage.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Springrbua - initial implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.layout.GridData;
@@ -30,19 +30,19 @@ import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
 public class NewNgModuleWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private static final String PAGE_NAME = "ngModule";
-	
+
 	private Button chkRouting;
 
-	protected NewNgModuleWizardPage(IProject project) {
-		super(PAGE_NAME, AngularCLIMessages.NewNgModuleWizardPage_title, null, NgBlueprint.MODULE, project);
+	protected NewNgModuleWizardPage(IContainer folder) {
+		super(PAGE_NAME, AngularCLIMessages.NewNgModuleWizardPage_title, null, NgBlueprint.MODULE, folder);
 		super.setDescription(AngularCLIMessages.NewNgModuleWizardPage_description);
 	}
-	
+
 	@Override
 	public void createParamsControl(Composite parent) {
 		super.createParamsControl(parent);
 		Font font = parent.getFont();
-		
+
 		// params group
 		Composite paramsGroup = new Composite(parent, SWT.NONE);
 		GridLayout layout = new GridLayout();
@@ -51,19 +51,19 @@ public class NewNgModuleWizardPage extends NgGenerateBlueprintWizardPage {
 		paramsGroup.setLayout(layout);
 		paramsGroup.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL));
 		paramsGroup.setFont(font);
-		
+
 		// Routing
 		Label label = new Label(paramsGroup, SWT.NONE);
 		label.setText(AngularCLIMessages.NewNgModuleWizardPage_routing);
 		label.setFont(font);
-		
+
 		// Checkbox for routing
 		chkRouting = new Button(paramsGroup, SWT.CHECK);
 		chkRouting.addListener(SWT.Modify, this);
 		GridData data = new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL);
 		chkRouting.setLayoutData(data);
 	}
-	
+
 	public boolean isRouting() {
 		return chkRouting.getSelection();
 	}

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgPipeWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgPipeWizard.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 
@@ -27,8 +27,8 @@ public class NewNgPipeWizard extends AbstractNewNgGenerateWizard {
 	}
 
 	@Override
-	protected NgGenerateBlueprintWizardPage createMainPage(IProject project) {
-		return new NewNgPipeWizardPage(project);
+	protected NgGenerateBlueprintWizardPage createMainPage(IContainer folder) {
+		return new NewNgPipeWizardPage(folder);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgPipeWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgPipeWizardPage.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
@@ -24,8 +24,8 @@ public class NewNgPipeWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private static final String PAGE_NAME = "ngPipe";
 
-	protected NewNgPipeWizardPage(IProject project) {
-		super(PAGE_NAME, AngularCLIMessages.NewNgPipeWizardPage_title, null, NgBlueprint.PIPE, project);
+	protected NewNgPipeWizardPage(IContainer folder) {
+		super(PAGE_NAME, AngularCLIMessages.NewNgPipeWizardPage_title, null, NgBlueprint.PIPE, folder);
 		super.setDescription(AngularCLIMessages.NewNgPipeWizardPage_description);
 	}
 

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgServiceWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgServiceWizard.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 
@@ -27,8 +27,8 @@ public class NewNgServiceWizard extends AbstractNewNgGenerateWizard {
 	}
 
 	@Override
-	protected NgGenerateBlueprintWizardPage createMainPage(IProject project) {
-		return new NewNgServiceWizardPage(project);
+	protected NgGenerateBlueprintWizardPage createMainPage(IContainer folder) {
+		return new NewNgServiceWizardPage(folder);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgServiceWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgServiceWizardPage.java
@@ -7,11 +7,11 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IContainer;
 
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
@@ -24,8 +24,8 @@ public class NewNgServiceWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private static final String PAGE_NAME = "ngService";
 
-	protected NewNgServiceWizardPage(IProject project) {
-		super(PAGE_NAME, AngularCLIMessages.NewNgServiceWizardPage_title, null, NgBlueprint.SERVICE, project);
+	protected NewNgServiceWizardPage(IContainer folder) {
+		super(PAGE_NAME, AngularCLIMessages.NewNgServiceWizardPage_title, null, NgBlueprint.SERVICE, folder);
 		super.setDescription(AngularCLIMessages.NewNgServiceWizardPage_description);
 	}
 


### PR DESCRIPTION
Closes angelozerr/angular2-eclipse#37

I replaced the project selection (Combobox) with folder selection (Textfield + "Browse"-Button).
The Angular-CLI command will then be executed inside the selected folder.
This does not mean, that the generated file(s)/folder(s) will be inside the selected folder, but the Angular-CLI will handle the selection correctly.
For example, if you select an invalid folder ("node_modules" for instance), the file(s)/folder(s) will be generated in "/src/app".