### PR TITLE
Add normalization of blueprint-name for file preview. See angelozerr/angular2-eclipse#44

### DIFF
--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/json/AngularCLIJson.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/json/AngularCLIJson.java
@@ -34,6 +34,9 @@ import ts.utils.StringUtils;
  */
 public class AngularCLIJson {
 
+	private static final String STRING_DASHERIZE_REGEXP = "[ _]";
+	private static final String STRING_DECAMELIZE_REGEXP = "([a-z\\d])([A-Z])";
+
 	private static final String DEFAULT_ROOT = "src";
 	private static final String APP = "app";
 
@@ -176,71 +179,79 @@ public class AngularCLIJson {
 		}
 	}
 
+	public static String decamelize(String str) {
+		return str.replaceAll(STRING_DECAMELIZE_REGEXP, "$1_$2").toLowerCase();
+	}
+
+	public static String normalize(String name) {
+		return decamelize(name).replaceAll(STRING_DASHERIZE_REGEXP, "-");
+	}
+
 	public String getTsFileName(String name) {
-		return name.concat(".ts");
+		return normalize(name).concat(".ts");
 	}
 
 	public String getSpecFileName(String name) {
-		return name.concat(".spec.ts");
+		return normalize(name).concat(".spec.ts");
 	}
 
 	public String getFolderName(String name) {
-		return name.concat("/");
+		return normalize(name).concat("/");
 	}
 
 	public String getComponentTsFileName(String name) {
-		return name.concat(".component.ts");
+		return normalize(name).concat(".component.ts");
 	}
 
 	public String getComponentSpecFileName(String name) {
-		return name.concat(".component.spec.ts");
+		return normalize(name).concat(".component.spec.ts");
 	}
 
 	public String getComponentTemplateFileName(String name) {
-		return name.concat(".component.html");
+		return normalize(name).concat(".component.html");
 	}
 
 	public String getComponentStyleFileName(String name) {
-		return name.concat(".component.").concat(getStylesExt());
+		return normalize(name).concat(".component.").concat(getStylesExt());
 	}
 
 	public String getDirectiveFileName(String name) {
-		return name.concat(".directive.ts");
+		return normalize(name).concat(".directive.ts");
 	}
 
 	public String getDirectiveSpecFileName(String name) {
-		return name.concat(".directive.spec.ts");
+		return normalize(name).concat(".directive.spec.ts");
 	}
 
 	public String getEnumFileName(String name) {
-		return name.concat(".enum.ts");
+		return normalize(name).concat(".enum.ts");
 	}
 
 	public String getModuleFileName(String name) {
-		return name.concat(".module.ts");
+		return normalize(name).concat(".module.ts");
 	}
 
 	public String getModuleSpecFileName(String name) {
-		return name.concat(".module.spec.ts");
+		return normalize(name).concat(".module.spec.ts");
 	}
 
 	public String getRoutingModuleFileName(String name) {
-		return name.concat("-routing.module.ts");
+		return normalize(name).concat("-routing.module.ts");
 	}
 
 	public String getPipeFileName(String name) {
-		return name.concat(".pipe.ts");
+		return normalize(name).concat(".pipe.ts");
 	}
 
 	public String getPipeSpecFileName(String name) {
-		return name.concat(".pipe.spec.ts");
+		return normalize(name).concat(".pipe.spec.ts");
 	}
 
 	public String getServiceFileName(String name) {
-		return name.concat(".service.ts");
+		return normalize(name).concat(".service.ts");
 	}
 
 	public String getServiceSpecFileName(String name) {
-		return name.concat(".service.spec.ts");
+		return normalize(name).concat(".service.spec.ts");
 	}
 }

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/launch/AngularCLILaunchConfigurationDelegate.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/launch/AngularCLILaunchConfigurationDelegate.java
@@ -71,7 +71,7 @@ public class AngularCLILaunchConfigurationDelegate implements ILaunchConfigurati
 			String[] options, IProgressMonitor monitor) throws CoreException {
 		// Define the terminal properties
 		IContainer container = WorkbenchResourceUtil.findContainerFromWorkspace(workingDir);
-		
+
 		Map<String, Object> properties = new HashMap<String, Object>();
 		properties.put(ITerminalsConnectorConstants.PROP_TITLE,
 				"angular-cli - [" + (container != null ? container.getProject().getName() : "") + "]");
@@ -79,7 +79,7 @@ public class AngularCLILaunchConfigurationDelegate implements ILaunchConfigurati
 		properties.put(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR, workingDir.toOSString());
 		properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID,
 				"ts.eclipse.ide.terminal.interpreter.LocalInterpreterLauncherDelegate");
-		
+
 		StringBuilder command = new StringBuilder("ng");
 		command.append(" ");
 		command.append(operation);
@@ -87,7 +87,6 @@ public class AngularCLILaunchConfigurationDelegate implements ILaunchConfigurati
 			command.append(" ");
 			command.append(options[i]);
 		}
-		
 
 		// Create the done callback object
 		ITerminalService.Done done = new ITerminalService.Done() {


### PR DESCRIPTION
The preview of the generated files now normalizes the given blueprint names.  
The normalization uses the same RegExp as Angular-CLI (See [ember-cli-string-utils](
https://github.com/ember-cli/ember-cli-string-utils/blob/master/index.js))