### PR TITLE
Updated Angular-CLI Pojos

### DIFF
--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.java
@@ -38,7 +38,7 @@ public class AngularCLIMessages extends NLS {
 	public static String AngularCLIConfigurationBlock_ngCustomFile_invalid_error;
 	public static String AngularCLIConfigurationBlock_ngCustomFile_notDir_error;
 	public static String AngularCLIConfigurationBlock_ValidatingNgCli_jobName;
-	
+
 	// Interpreter
 	public static String NgServeJob_jobName;
 	public static String NgServeJob_error;
@@ -54,7 +54,7 @@ public class AngularCLIMessages extends NLS {
 	public static String NewAngular2ProjectWizard_windowTitle;
 	public static String NewAngular2ProjectWizard_newProjectTitle;
 	public static String NewAngular2ProjectWizard_newProjectDescription;
-	
+
 	public static String NewAngular2ProjectParamsWizardPage_title;
 	public static String NewAngular2ProjectParamsWizardPage_prefix;
 	public static String NewAngular2ProjectParamsWizardPage_sourceDir;

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.properties
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.properties
@@ -69,7 +69,7 @@ NgGenerateBlueprintWizardPage_invalid_apps_location_error=Location must be inclu
 NgGenerateBlueprintWizardPage_file_already_exist=File ''{0}'' already exists.
 
 NgGenerateBlueprintWizardPage_generate_spec=Generate &spec file
-NgGenerateBlueprintWizardPage_prefix=&Prefix
+NgGenerateBlueprintWizardPage_prefix=&Prefix:
 NgGenerateBlueprintWizardPage_flat=&Flat
 NgGenerateBlueprintWizardPage_skipImport=Skip &import
 NgGenerateBlueprintWizardPage_export=&Export
@@ -84,8 +84,8 @@ NewNgComponentWizardPage_title=Angular2 Component
 NewNgComponentWizardPage_description=Create a new Angular2 Component with @angular/cli 'ng g component $name'.
 NewNgComponentWizardPage_inlineTemplate=Inline &template
 NewNgComponentWizardPage_inlineStyle=&Inline style
-NewNgComponentWizardPage_viewEncapsulation=&View encapsulation
-NewNgComponentWizardPage_changeDetection=&Change detection
+NewNgComponentWizardPage_viewEncapsulation=&View encapsulation:
+NewNgComponentWizardPage_changeDetection=&Change detection:
 
 NewNgDirectiveWizard_windowTitle=New Angular2 Directive
 NewNgDirectiveWizardPage_title=Angular2 Directive

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/json/AngularCLIJson.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/json/AngularCLIJson.java
@@ -72,13 +72,8 @@ public class AngularCLIJson {
 		// Search root from the angular-cli.json apps[0].root
 		String root = getRootFromApps();
 		if (StringUtils.isEmpty(root)) {
-			// Not found, search root from the angular-cli.json
-			// defaults.sourceDir
-			root = getSourceDirFromDefaults();
-			if (StringUtils.isEmpty(root)) {
-				// Not found, use default "src" value
-				root = DEFAULT_ROOT;
-			}
+			// Not found, use default "src" value
+			root = DEFAULT_ROOT;
 		}
 		return new Path("/").append(project.getName()).append(root).append(APP);
 	}
@@ -91,27 +86,55 @@ public class AngularCLIJson {
 		return apps.get(0).getRoot();
 	}
 
-	private String getSourceDirFromDefaults() {
-		Defaults defaults = getDefaults();
-		if (defaults == null) {
-			return null;
-		}
-		return defaults.getSourceDir();
-	}
-
-	public String getPrefix() {
-		// Search prefix from the angular-cli.json apps[0].prefix
-		String prefix = getPrefixFromApps();
-		if (StringUtils.isEmpty(prefix)) {
-			// Not found, search prefix from the angular-cli.json
-			// defaults.prefix
-			prefix = getPrefixFromDefaults();
+	public String getPrefix(NgBlueprint blueprint) {
+		GenerateDefaults gDefaults = getGenerateDefaults(blueprint);
+		String prefix = gDefaults != null ? gDefaults.getPrefix() : null;
+		if (StringUtils.isEmpty(prefix) && blueprint != NgBlueprint.INTERFACE) {
+			// Search prefix from the angular-cli.json apps[0].prefix
+			prefix = getPrefixFromApps();
 			if (StringUtils.isEmpty(prefix)) {
 				// Not found, use default "app" value
 				prefix = APP;
 			}
 		}
 		return prefix;
+	}
+
+	public GenerateDefaults getGenerateDefaults(NgBlueprint blueprint) {
+		Defaults defaults = getDefaults();
+		GenerateDefaults gDefaults = null;
+		if (defaults != null) {
+			switch(blueprint) {
+			case CLASS:
+				gDefaults = defaults.getCliClass();
+				break;
+			case COMPONENT:
+				gDefaults = defaults.getComponent();
+				break;
+			case DIRECTIVE:
+				gDefaults = defaults.getDirective();
+				break;
+			case ENUM:
+				gDefaults = defaults.getCliEnum();
+				break;
+			case GUARD:
+				gDefaults = defaults.getGuard();
+				break;
+			case INTERFACE:
+				gDefaults = defaults.getCliInterface();
+				break;
+			case MODULE:
+				gDefaults = defaults.getModule();
+				break;
+			case PIPE:
+				gDefaults = defaults.getPipe();
+				break;
+			case SERVICE:
+				gDefaults = defaults.getService();
+				break;
+			}
+		}
+		return gDefaults;
 	}
 
 	private String getPrefixFromApps() {
@@ -122,64 +145,9 @@ public class AngularCLIJson {
 		return apps.get(0).getPrefix();
 	}
 
-	public String getPrefixFromDefaults() {
-		Defaults defaults = getDefaults();
-		if (defaults == null)
-			return null;
-		else
-			return defaults.getPrefix();
-	}
-
 	public String getStylesExt() {
 		Defaults defaults = getDefaults();
 		return defaults != null ? defaults.getStyleExt() : null;
-	}
-
-	public boolean isInlineTempalte() {
-		Defaults defaults = getDefaults();
-		Inline inline = defaults != null ? defaults.getInline() : null;
-		if (inline == null)
-			return false;
-		else
-			return inline.isTemplate();
-	}
-
-	public boolean isInlineStyle() {
-		Defaults defaults = getDefaults();
-		Inline inline = defaults != null ? defaults.getInline() : null;
-		if (inline == null)
-			return false;
-		else
-			return inline.isStyle();
-	}
-
-	public boolean isSpec(NgBlueprint blueprint) {
-		Defaults defaults = getDefaults();
-		Spec spec = defaults != null ? defaults.getSpec() : null;
-		if (spec == null)
-			return false;
-		else {
-			switch (blueprint) {
-			case MODULE:
-				return spec.isModule();
-			case COMPONENT:
-				return spec.isComponent();
-			case DIRECTIVE:
-				return spec.isDirective();
-			case PIPE:
-				return spec.isPipe();
-			case SERVICE:
-				return spec.isService();
-			case GUARD:
-				return spec.isGuard();
-			case CLASS:
-				return spec.isClass();
-			// case INTERFACE:
-			// case ENUM:
-			default:
-				return false;
-			}
-		}
 	}
 
 	public static String decamelize(String str) {
@@ -228,6 +196,14 @@ public class AngularCLIJson {
 
 	public String getEnumFileName(String name) {
 		return normalize(name).concat(".enum.ts");
+	}
+
+	public String getInterfaceFileName(String name, String prefix) {
+		String fileName = normalize(name);
+		if (prefix != null && prefix.length() > 0)
+			fileName = fileName.concat(".").concat(prefix);
+		fileName = fileName.concat(".ts");
+		return fileName;
 	}
 
 	public String getModuleFileName(String name) {

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/json/Defaults.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/json/Defaults.java
@@ -11,51 +11,74 @@
  */
 package ts.eclipse.ide.angular2.internal.cli.json;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Pojo for "defaults" of angular-cli.json
  *
  */
 public class Defaults {
 
-	private String prefix;
-
-	private String sourceDir;
-
 	private String styleExt;
 
-	private boolean prefixInterfaces;
+	@SerializedName("class")
+	private GenerateDefaults cliClass;
 
-	private String lazyRoutePrefix;
+	private GenerateDefaults component;
 
-	private Spec spec;
+	private GenerateDefaults directive;
 
-	private Inline inline;
+	@SerializedName("enum")
+	private GenerateDefaults cliEnum;
 
-	public String getPrefix() {
-		return prefix;
-	}
+	private GenerateDefaults guard;
 
-	public String getSourceDir() {
-		return sourceDir;
-	}
+	@SerializedName("interface")
+	private GenerateDefaults cliInterface;
+
+	private GenerateDefaults module;
+
+	private GenerateDefaults pipe;
+
+	private GenerateDefaults service;
 
 	public String getStyleExt() {
 		return styleExt;
 	}
 
-	public boolean isPrefixInterfaces() {
-		return prefixInterfaces;
+	public GenerateDefaults getCliClass() {
+		return cliClass;
 	}
 
-	public String getLazyRoutePrefix() {
-		return lazyRoutePrefix;
+	public GenerateDefaults getComponent() {
+		return component;
 	}
 
-	public Spec getSpec() {
-		return spec;
+	public GenerateDefaults getDirective() {
+		return directive;
 	}
 
-	public Inline getInline() {
-		return inline;
+	public GenerateDefaults getCliEnum() {
+		return cliEnum;
+	}
+
+	public GenerateDefaults getGuard() {
+		return guard;
+	}
+
+	public GenerateDefaults getCliInterface() {
+		return cliInterface;
+	}
+
+	public GenerateDefaults getModule() {
+		return module;
+	}
+
+	public GenerateDefaults getPipe() {
+		return pipe;
+	}
+
+	public GenerateDefaults getService() {
+		return service;
 	}
 }

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/json/GenerateDefaults.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/json/GenerateDefaults.java
@@ -1,0 +1,105 @@
+/**
+ *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Springrbua - initial API and implementation
+ *
+ */
+package ts.eclipse.ide.angular2.internal.cli.json;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Pojo for different "defaults" for the generate commands of angular-cli.json.
+ * Note, that not every "defaults" supports all of the fields.
+ *
+ */
+public class GenerateDefaults {
+
+	// Constants for ViewEncapsulation
+	public static final String VE_EMULATED	= "Emulated";
+	public static final String VE_NATIVE	= "Native";
+	public static final String VE_NONE		= "None";
+
+	// Constants for ChangeDetectionStrategy
+	public static final String CD_ON_PUSH	= "OnPush";
+	public static final String CD_DEFAULT	= "Default";
+
+	@SerializedName("change-detection")
+	private String changeDetection;
+
+	private boolean flat;
+
+	@SerializedName("inline-style")
+	private boolean inlineStyle;
+
+	@SerializedName("inline-template")
+	private boolean inlineTemplate;
+
+	private String prefix;
+
+	private boolean spec;
+
+	@SerializedName("view-encapsulation")
+	private String viewEncapsulation;
+
+	public String getChangeDetection() {
+		return checkChangeDetection(changeDetection);
+	}
+
+	public static String checkChangeDetection(String cd) {
+		if (cd != null) {
+			switch (cd) {
+			case CD_DEFAULT:
+			case CD_ON_PUSH:
+				return cd;
+			default:
+				return CD_DEFAULT;
+			}
+		}
+		return CD_DEFAULT;
+	}
+
+	public boolean isFlat() {
+		return flat;
+	}
+
+	public boolean isInlineStyle() {
+		return inlineStyle;
+	}
+
+	public boolean isInlineTemplate() {
+		return inlineTemplate;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public boolean isSpec() {
+		return spec;
+	}
+
+	public String getViewEncapsulation() {
+		return checkViewEncapsulation(viewEncapsulation);
+	}
+
+	public static String checkViewEncapsulation(String ve) {
+		if (ve != null) {
+			switch (ve) {
+			case VE_EMULATED:
+			case VE_NATIVE:
+			case VE_NONE:
+				return ve;
+			default:
+				return VE_EMULATED;
+			}
+		}
+		return VE_EMULATED;
+	}
+
+}

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgClassWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgClassWizardPage.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Composite;
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
 import ts.eclipse.ide.angular2.internal.cli.json.AngularCLIJson;
+import ts.eclipse.ide.angular2.internal.cli.json.GenerateDefaults;
 
 /**
  * Wizard page for Angular2 Class.
@@ -63,9 +64,10 @@ public class NewNgClassWizardPage extends NgGenerateBlueprintWizardPage {
 	@Override
 	protected void initializeDefaultValues() {
 		super.initializeDefaultValues();
-		chkSpec.setSelection(getAngularCLIJson().isSpec(NgBlueprint.CLASS));
+		GenerateDefaults gDefaults = getAngularCLIJson().getGenerateDefaults(NgBlueprint.CLASS);
+		chkSpec.setSelection(gDefaults != null ? gDefaults.isSpec() : false);
 	}
-	
+
 	@Override
 	protected String[] getGeneratedFilesImpl() {
 		AngularCLIJson cliJson = getAngularCLIJson();

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgComponentWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgComponentWizard.java
@@ -16,6 +16,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
+import ts.eclipse.ide.angular2.internal.cli.json.GenerateDefaults;
 
 /**
  * Wizard to generate Angular2 Component with "ng generate component $name".
@@ -53,10 +54,10 @@ public class NewNgComponentWizard extends AbstractNewNgGenerateWizard {
 		sb.append(' ').append("--spec ").append(mainPage.isSpec());
 		sb.append(' ').append("--flat ").append(mainPage.isFlat());
 		String viewEncapsulation = mainPage.getViewEncapsulation();
-		if (!NewNgComponentWizardPage.VE_EMULATED.equals(viewEncapsulation))
+		if (!GenerateDefaults.VE_EMULATED.equals(viewEncapsulation))
 			sb.append(' ').append("--view-encapsulation ").append(viewEncapsulation);
 		String changeDetection = mainPage.getChangeDetection();
-		if (!NewNgComponentWizardPage.CD_DEFAULT.equals(changeDetection))
+		if (!GenerateDefaults.CD_DEFAULT.equals(changeDetection))
 			sb.append(' ').append("--change-detection ").append(changeDetection);
 	}
 }

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgComponentWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgComponentWizardPage.java
@@ -25,21 +25,13 @@ import org.eclipse.swt.widgets.Text;
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
 import ts.eclipse.ide.angular2.internal.cli.json.AngularCLIJson;
+import ts.eclipse.ide.angular2.internal.cli.json.GenerateDefaults;
 
 /**
  * Wizard page for Angular2 Component.
  *
  */
 public class NewNgComponentWizardPage extends NgGenerateBlueprintWizardPage {
-
-	// Constants for ViewEncapsulation
-	public static final String VE_EMULATED = "Emulated";
-	public static final String VE_NATIVE = "Native";
-	public static final String VE_NONE = "None";
-
-	// Constants for ChangeDetectionStrategy
-	public static final String CD_ON_PUSH = "OnPush";
-	public static final String CD_DEFAULT = "Default";
 
 	private static final String PAGE_NAME = "ngComponent";
 
@@ -107,9 +99,9 @@ public class NewNgComponentWizardPage extends NgGenerateBlueprintWizardPage {
 		cbViewEncapsulation.setLayoutData(data);
 
 		// Data for view encapsulation
-		cbViewEncapsulation.add(VE_EMULATED);
-		cbViewEncapsulation.add(VE_NATIVE);
-		cbViewEncapsulation.add(VE_NONE);
+		cbViewEncapsulation.add(GenerateDefaults.VE_EMULATED);
+		cbViewEncapsulation.add(GenerateDefaults.VE_NATIVE);
+		cbViewEncapsulation.add(GenerateDefaults.VE_NONE);
 
 		// Change detection
 		label = new Label(subGroup, SWT.NONE);
@@ -123,8 +115,8 @@ public class NewNgComponentWizardPage extends NgGenerateBlueprintWizardPage {
 		cbChangeDetection.setLayoutData(data);
 
 		// Data for change detection
-		cbChangeDetection.add(CD_ON_PUSH);
-		cbChangeDetection.add(CD_DEFAULT);
+		cbChangeDetection.add(GenerateDefaults.CD_ON_PUSH);
+		cbChangeDetection.add(GenerateDefaults.CD_DEFAULT);
 
 		// Checkbox for flat
 		chkFlat = new Button(paramsGroup, SWT.CHECK);
@@ -172,14 +164,16 @@ public class NewNgComponentWizardPage extends NgGenerateBlueprintWizardPage {
 	@Override
 	protected void initializeDefaultValues() {
 		super.initializeDefaultValues();
-		String prefix = getAngularCLIJson().getPrefix();
+		GenerateDefaults gDefaults = getAngularCLIJson().getGenerateDefaults(NgBlueprint.COMPONENT);
+		String prefix = getAngularCLIJson().getPrefix(NgBlueprint.COMPONENT);
 		if (prefix != null)
 			txtPrefix.setText(prefix);
-		chkInlineTemplate.setSelection(getAngularCLIJson().isInlineTempalte());
-		chkInlineStyle.setSelection(getAngularCLIJson().isInlineStyle());
-		chkSpec.setSelection(getAngularCLIJson().isSpec(NgBlueprint.COMPONENT));
-		cbViewEncapsulation.select(cbViewEncapsulation.indexOf(VE_EMULATED));
-		cbChangeDetection.select(cbChangeDetection.indexOf(CD_DEFAULT));
+		chkFlat.setSelection(gDefaults != null ? gDefaults.isFlat() : false);
+		chkSpec.setSelection(gDefaults != null ? gDefaults.isInlineStyle() : true);
+		chkInlineStyle.setSelection(gDefaults != null ? gDefaults.isInlineStyle() : false);
+		chkInlineTemplate.setSelection(gDefaults != null ? gDefaults.isInlineTemplate() : false);
+		cbViewEncapsulation.select(cbViewEncapsulation.indexOf(gDefaults != null ? gDefaults.getViewEncapsulation() : GenerateDefaults.VE_EMULATED));
+		cbChangeDetection.select(cbChangeDetection.indexOf(gDefaults != null ? gDefaults.getChangeDetection() : GenerateDefaults.CD_DEFAULT));
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgDirectiveWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgDirectiveWizardPage.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Text;
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
 import ts.eclipse.ide.angular2.internal.cli.json.AngularCLIJson;
+import ts.eclipse.ide.angular2.internal.cli.json.GenerateDefaults;
 
 /**
  * Wizard page for Angular2 Directive.
@@ -113,9 +114,10 @@ public class NewNgDirectiveWizardPage extends NgGenerateBlueprintWizardPage {
 	@Override
 	protected void initializeDefaultValues() {
 		super.initializeDefaultValues();
-		txtPrefix.setText(getAngularCLIJson().getPrefix());
-		chkSpec.setSelection(getAngularCLIJson().isSpec(NgBlueprint.DIRECTIVE));
-		chkFlat.setSelection(true);
+		GenerateDefaults gDefaults = getAngularCLIJson().getGenerateDefaults(NgBlueprint.DIRECTIVE);
+		txtPrefix.setText(getAngularCLIJson().getPrefix(NgBlueprint.COMPONENT));
+		chkFlat.setSelection(gDefaults != null ? gDefaults.isFlat() : true);
+		chkSpec.setSelection(gDefaults != null ? gDefaults.isSpec() : false);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgGuardWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgGuardWizardPage.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Composite;
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
 import ts.eclipse.ide.angular2.internal.cli.json.AngularCLIJson;
+import ts.eclipse.ide.angular2.internal.cli.json.GenerateDefaults;
 
 /**
  * Wizard page for Angular2 Guard.
@@ -71,8 +72,9 @@ public class NewNgGuardWizardPage extends NgGenerateBlueprintWizardPage {
 	@Override
 	protected void initializeDefaultValues() {
 		super.initializeDefaultValues();
-		chkSpec.setSelection(getAngularCLIJson().isSpec(NgBlueprint.GUARD));
-		chkFlat.setSelection(true);
+		GenerateDefaults gDefaults = getAngularCLIJson().getGenerateDefaults(NgBlueprint.GUARD);
+		chkSpec.setSelection(gDefaults != null ? gDefaults.isSpec() : false);
+		chkFlat.setSelection(gDefaults != null ? gDefaults.isFlat() : true);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgInterfaceWizard.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgInterfaceWizard.java
@@ -36,4 +36,13 @@ public class NewNgInterfaceWizard extends AbstractNewNgGenerateWizard {
 		super.init(workbench, selection);
 		super.setWindowTitle(AngularCLIMessages.NewNgInterfaceWizard_windowTitle);
 	}
+
+	@Override
+	protected void appendOperationParameters(StringBuilder sb) {
+		super.appendOperationParameters(sb);
+		NewNgInterfaceWizardPage mainPage = (NewNgInterfaceWizardPage)getMainPage();
+		String prefix = mainPage.getPrefix();
+		if (prefix != null && prefix.length() > 0)
+			sb.append(' ').append("--prefix ").append(prefix);
+	}
 }

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgInterfaceWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgInterfaceWizardPage.java
@@ -12,6 +12,13 @@
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
 import org.eclipse.core.resources.IContainer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
@@ -25,16 +32,57 @@ public class NewNgInterfaceWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private static final String PAGE_NAME = "ngInterface";
 
+	private Text txtPrefix;
+
 	protected NewNgInterfaceWizardPage(IContainer folder) {
 		super(PAGE_NAME, AngularCLIMessages.NewNgInterfaceWizardPage_title, null, NgBlueprint.INTERFACE, folder);
 		super.setDescription(AngularCLIMessages.NewNgInterfaceWizardPage_description);
 	}
 
 	@Override
+	protected void createParamsControl(Composite parent) {
+		super.createParamsControl(parent);
+		Font font = parent.getFont();
+
+		// params group
+		Composite paramsGroup = new Composite(parent, SWT.NONE);
+		GridLayout layout = new GridLayout();
+		layout.numColumns = 2;
+		layout.marginWidth = 0;
+		paramsGroup.setLayout(layout);
+		paramsGroup.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL));
+		paramsGroup.setFont(font);
+
+		// Label for prefix
+		Label label = new Label(paramsGroup, SWT.NONE);
+		label.setText(AngularCLIMessages.NgGenerateBlueprintWizardPage_prefix);
+		label.setFont(font);
+
+		// Textfield for prefix
+		txtPrefix = new Text(paramsGroup, SWT.BORDER);
+		txtPrefix.addListener(SWT.Modify, this);
+		GridData data = new GridData(GridData.FILL_HORIZONTAL);
+		txtPrefix.setLayoutData(data);
+		txtPrefix.setFont(font);
+	}
+
+	@Override
+	protected void initializeDefaultValues() {
+		super.initializeDefaultValues();
+		String prefix = getAngularCLIJson().getPrefix(NgBlueprint.INTERFACE);
+		if (prefix != null)
+			txtPrefix.setText(prefix);
+	}
+
+	@Override
 	protected String[] getGeneratedFilesImpl() {
 		AngularCLIJson cliJson = getAngularCLIJson();
 		String name = getBlueprintName();
-		return new String[] { cliJson.getTsFileName(name) };
+		return new String[] { cliJson.getInterfaceFileName(name, getPrefix()) };
+	}
+
+	public String getPrefix() {
+		return txtPrefix.getText();
 	}
 
 }

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgModuleWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgModuleWizardPage.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Composite;
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
 import ts.eclipse.ide.angular2.internal.cli.json.AngularCLIJson;
+import ts.eclipse.ide.angular2.internal.cli.json.GenerateDefaults;
 
 /**
  * Wizard page for Angular2 Module.
@@ -33,6 +34,7 @@ public class NewNgModuleWizardPage extends NgGenerateBlueprintWizardPage {
 
 	private Button chkRouting;
 	private Button chkSpec;
+	private Button chkFlat;
 
 	protected NewNgModuleWizardPage(IContainer folder) {
 		super(PAGE_NAME, AngularCLIMessages.NewNgModuleWizardPage_title, null, NgBlueprint.MODULE, folder);
@@ -66,12 +68,21 @@ public class NewNgModuleWizardPage extends NgGenerateBlueprintWizardPage {
 		chkSpec.setText(AngularCLIMessages.NgGenerateBlueprintWizardPage_generate_spec);
 		data = new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL);
 		chkSpec.setLayoutData(data);
+
+		// Checkbox for flat
+		chkFlat = new Button(paramsGroup, SWT.CHECK);
+		chkFlat.addListener(SWT.Selection, this);
+		chkFlat.setText(AngularCLIMessages.NgGenerateBlueprintWizardPage_flat);
+		data = new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL);
+		chkFlat.setLayoutData(data);
 	}
 
 	@Override
 	protected void initializeDefaultValues() {
 		super.initializeDefaultValues();
-		chkSpec.setSelection(getAngularCLIJson().isSpec(NgBlueprint.MODULE));
+		GenerateDefaults gDefaults = getAngularCLIJson().getGenerateDefaults(NgBlueprint.MODULE);
+		chkSpec.setSelection(gDefaults != null ? gDefaults.isSpec() : false);
+		chkFlat.setSelection(gDefaults != null ? gDefaults.isFlat() : false);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgPipeWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgPipeWizardPage.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Composite;
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
 import ts.eclipse.ide.angular2.internal.cli.json.AngularCLIJson;
+import ts.eclipse.ide.angular2.internal.cli.json.GenerateDefaults;
 
 /**
  * Wizard page for Angular2 Pipe.
@@ -87,8 +88,9 @@ public class NewNgPipeWizardPage extends NgGenerateBlueprintWizardPage {
 	@Override
 	protected void initializeDefaultValues() {
 		super.initializeDefaultValues();
-		chkSpec.setSelection(getAngularCLIJson().isSpec(NgBlueprint.PIPE));
-		chkFlat.setSelection(true);
+		GenerateDefaults gDefaults = getAngularCLIJson().getGenerateDefaults(NgBlueprint.PIPE);
+		chkFlat.setSelection(gDefaults != null ? gDefaults.isFlat() : true);
+		chkSpec.setSelection(gDefaults != null ? gDefaults.isSpec() : false);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgServiceWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewNgServiceWizardPage.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Composite;
 import ts.eclipse.ide.angular2.cli.NgBlueprint;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
 import ts.eclipse.ide.angular2.internal.cli.json.AngularCLIJson;
+import ts.eclipse.ide.angular2.internal.cli.json.GenerateDefaults;
 
 /**
  * Wizard page for Angular2 Service.
@@ -71,8 +72,9 @@ public class NewNgServiceWizardPage extends NgGenerateBlueprintWizardPage {
 	@Override
 	protected void initializeDefaultValues() {
 		super.initializeDefaultValues();
-		chkSpec.setSelection(getAngularCLIJson().isSpec(NgBlueprint.SERVICE));
-		chkFlat.setSelection(true);
+		GenerateDefaults gDefaults = getAngularCLIJson().getGenerateDefaults(NgBlueprint.SERVICE);
+		chkSpec.setSelection(gDefaults != null ? gDefaults.isSpec() : true);
+		chkFlat.setSelection(gDefaults != null ? gDefaults.isFlat() : true);
 	}
 
 	@Override


### PR DESCRIPTION
I updated the Angular-CLI Pojos to match the Schema of the final Version of Angular-CLI.  
Instead of creating a separate Pojo for every Default (Component, Directive, Service, etc.), I created one Pojo with all properties (See [GenerateDefaults.java](https://github.com/Springrbua/angular2-eclipse/blob/master/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/json/GenerateDefaults.java)).  
The properties for a specific "generate" command are then evaluated in the Wizard-Page and the fields are initialized with this default values.