### PR TITLE
Add validation for Angular-CLI project name. See angelozerr/angular2-eclipse#75

### DIFF
--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.java
@@ -54,6 +54,7 @@ public class AngularCLIMessages extends NLS {
 	public static String NewAngular2ProjectWizard_windowTitle;
 	public static String NewAngular2ProjectWizard_newProjectTitle;
 	public static String NewAngular2ProjectWizard_newProjectDescription;
+	public static String NewAngular2ProjectWizard_invalidProjectName;
 
 	public static String NewAngular2ProjectParamsWizardPage_title;
 	public static String NewAngular2ProjectParamsWizardPage_prefix;

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.properties
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.properties
@@ -42,6 +42,7 @@ You should consider renaming either the project in workspace, or editing the .pr
 NewAngular2ProjectWizard_windowTitle=New Angular Project
 NewAngular2ProjectWizard_newProjectTitle=Create an Angular Project
 NewAngular2ProjectWizard_newProjectDescription=Create an Angular project in the workspace or in an external location.
+NewAngular2ProjectWizard_invalidProjectName=Invalid Project name
 
 NewAngular2ProjectParamsWizardPage_title=Optional Params
 NewAngular2ProjectParamsWizardPage_prefix=&Prefix:

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/WizardNewNgProjectCreationPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/WizardNewNgProjectCreationPage.java
@@ -14,6 +14,8 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.ui.wizards.newresource.BasicNewResourceWizard;
 
+import ts.eclipse.ide.angular2.cli.AngularCLIPlugin;
+import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
 import ts.eclipse.ide.ui.wizards.WizardNewTypeScriptProjectCreationPage;
 
 /**
@@ -21,6 +23,11 @@ import ts.eclipse.ide.ui.wizards.WizardNewTypeScriptProjectCreationPage;
  *
  */
 public class WizardNewNgProjectCreationPage extends WizardNewTypeScriptProjectCreationPage {
+
+	public static final String projectNameRegexp = "^[a-zA-Z][.0-9a-zA-Z]*(-[.0-9a-zA-Z]*)*$";
+	public static final String[] unsupportedProjectNames = new String[] { "test", "ember", "ember-cli", "vendor", "app" };
+
+	private static final Status ERROR_STATUS = new Status(IStatus.ERROR, AngularCLIPlugin.PLUGIN_ID, AngularCLIMessages.NewAngular2ProjectWizard_invalidProjectName);
 
 	public WizardNewNgProjectCreationPage(String pageName, BasicNewResourceWizard wizard) {
 		super(pageName, wizard);
@@ -35,12 +42,27 @@ public class WizardNewNgProjectCreationPage extends WizardNewTypeScriptProjectCr
 				return false;
 			}
 		}
-		return false;
+		return true;
 	}
 
 	private IStatus validateNgProjectName(String name) {
-		// TODO: validate name and returns Error status if error.
-		return Status.OK_STATUS;
+		IStatus status = name != null && name.length() > 0 ? Status.OK_STATUS : ERROR_STATUS;
+		for (int i = 0, cnt = unsupportedProjectNames.length; i < cnt; i++) {
+			if (unsupportedProjectNames[i].equals(name)) {
+				status = ERROR_STATUS;
+				break;
+			}
+		}
+		if (status.isOK()) {
+			String[] parts = name.split("-");
+			for (int i = 0, cnt = parts.length; i < cnt; i++) {
+				if (!parts[i].matches(projectNameRegexp)) {
+					status = ERROR_STATUS;
+					break;
+				}
+			}
+		}
+		return status;
 	}
 
 }


### PR DESCRIPTION
The validation first checks for the invalid names ("test", "ember", "ember-cli", "vendor", "app"). This test is case sensitive, so a Project named "Test" would be valid.  
After that, the project name is split on every dash ("-") and every part is checked against the following Regex:  
`^[a-zA-Z][.0-9a-zA-Z]*(-[.0-9a-zA-Z]*)*$`  
If the part does not match, the name is invalid.