### PR TITLE
Add install of Angular-CLI in new Angular2 Project

### DIFF
--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/cli/utils/CLIStatus.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/cli/utils/CLIStatus.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (c) 2015-2016 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Springrbua
+ */
+package ts.eclipse.ide.angular2.cli.utils;
+
+import java.io.File;
+
+import ts.eclipse.ide.ui.preferences.StatusInfo;
+
+/** Class which holds the status of a specific Angular-CLI installation. */
+public class CLIStatus extends StatusInfo {
+
+	private final File ngFile;
+	private String version;
+
+	public CLIStatus(File ngFile, String errorMessage) {
+		if (errorMessage != null) {
+			setError(errorMessage);
+		}
+		this.ngFile = ngFile;
+	}
+
+	public File getNgFile() {
+		return ngFile;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+}

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/cli/utils/NgVersionJob.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/cli/utils/NgVersionJob.java
@@ -1,0 +1,74 @@
+/**
+ *  Copyright (c) 2015-2016 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Springrbua
+ */
+package ts.eclipse.ide.angular2.cli.utils;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.osgi.util.NLS;
+
+import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
+import ts.utils.FileUtils;
+import ts.utils.StringUtils;
+
+/** Class for executing "ng --version" Command. */
+public class NgVersionJob extends Job {
+
+	private File nodeFile;
+	private File ngFile;
+
+	public NgVersionJob() {
+		super(AngularCLIMessages.AngularCLIConfigurationBlock_ValidatingNgCli_jobName);
+	}
+
+	/** Sets the NodeJS-File for this Job. */
+	public void setNodeFile(File nodeFile) {
+		this.nodeFile = nodeFile;
+	}
+
+	/** Sets the Ng-File for this Job. */
+	public void setNgFile(File ngFile) {
+		this.ngFile = ngFile;
+	}
+
+	@Override
+	protected IStatus run(IProgressMonitor monitor) {
+		if (monitor.isCanceled()) {
+			return Status.CANCEL_STATUS;
+		}
+		File currentNgFile = ngFile;
+		if (currentNgFile == null) {
+			return Status.CANCEL_STATUS;
+		}
+		String version = null;
+		String errorMessage = null;
+		try {
+			version = CLIProcessHelper.getNgVersion(currentNgFile, nodeFile);
+		} catch (IOException e) {
+			errorMessage = e.getMessage();
+		}
+		final CLIStatus status = StringUtils.isEmpty(version) ? new CLIStatus(null,
+				errorMessage != null ? errorMessage
+						: NLS.bind(AngularCLIMessages.AngularCLIConfigurationBlock_ngCustomFile_invalid_error,
+								FileUtils.getPath(currentNgFile)))
+				: new CLIStatus(currentNgFile, null);
+		status.setVersion(version);
+		if (monitor.isCanceled() || !currentNgFile.equals(ngFile)) {
+			return Status.CANCEL_STATUS;
+		}
+		return status;
+	}
+}

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.java
@@ -56,7 +56,13 @@ public class AngularCLIMessages extends NLS {
 	public static String NewAngular2ProjectWizard_newProjectDescription;
 	public static String NewAngular2ProjectWizard_invalidProjectName;
 	public static String NewAngular2ProjectWizard_unsupportedProjectNames;
-	
+
+	public static String WizardNewNgProjectCreationPage_angular_cli_group_label;
+	public static String WizardNewNgProjectCreationPage_useGlobalAngularCLI;
+	public static String WizardNewNgProjectCreationPage_useInstallAngularCLI;
+	public static String WizardNewNgProjectCreationPage_searchingForGlobalAngularCLI;
+	public static String WizardNewNgProjectCreationPage_noGlobalAngularCLI;
+
 	public static String NewAngular2ProjectParamsWizardPage_title;
 	public static String NewAngular2ProjectParamsWizardPage_prefix;
 	public static String NewAngular2ProjectParamsWizardPage_sourceDir;

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.properties
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/AngularCLIMessages.properties
@@ -45,6 +45,12 @@ NewAngular2ProjectWizard_newProjectDescription=Create an Angular project in the 
 NewAngular2ProjectWizard_invalidProjectName=Project name "{0}" is not valid. New project names must start with a letter, and must contain only alphanumeric characters or dashes. When adding a dash the segment after the dash must also start with a letter.
 NewAngular2ProjectWizard_unsupportedProjectNames=Project name "{0}" is not a supported name.
 
+WizardNewNgProjectCreationPage_angular_cli_group_label=Angular CLI
+WizardNewNgProjectCreationPage_useGlobalAngularCLI=Use global
+WizardNewNgProjectCreationPage_useInstallAngularCLI=Install
+WizardNewNgProjectCreationPage_searchingForGlobalAngularCLI=Searching for global Angular CLI...
+WizardNewNgProjectCreationPage_noGlobalAngularCLI=No global Angular CLI installation found.
+
 NewAngular2ProjectParamsWizardPage_title=Optional Params
 NewAngular2ProjectParamsWizardPage_prefix=&Prefix:
 NewAngular2ProjectParamsWizardPage_sourceDir=Source &dir:

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/terminal/NgCommandInterpreterFactory.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/terminal/NgCommandInterpreterFactory.java
@@ -7,7 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  
+ *
  */
 package ts.eclipse.ide.angular2.internal.cli.terminal;
 
@@ -75,8 +75,7 @@ public class NgCommandInterpreterFactory implements ICommandInterpreterFactory, 
 		if (parameters.size() < 2) {
 			return null;
 		}
-		String projectName = parameters.get(1);
-		return new File(workingDir, projectName);
+		return new File(workingDir);
 	}
 
 	@Override

--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/WizardNewNgProjectCreationPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/WizardNewNgProjectCreationPage.java
@@ -10,14 +10,40 @@
  */
 package ts.eclipse.ide.angular2.internal.cli.wizards;
 
+import java.io.File;
+import java.util.List;
+
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.wizards.newresource.BasicNewResourceWizard;
+import org.osgi.service.prefs.BackingStoreException;
 
 import ts.eclipse.ide.angular2.cli.AngularCLIPlugin;
+import ts.eclipse.ide.angular2.cli.preferences.AngularCLIPreferenceConstants;
+import ts.eclipse.ide.angular2.cli.utils.CLIProcessHelper;
+import ts.eclipse.ide.angular2.cli.utils.CLIStatus;
+import ts.eclipse.ide.angular2.cli.utils.NgVersionJob;
 import ts.eclipse.ide.angular2.internal.cli.AngularCLIMessages;
+import ts.eclipse.ide.terminal.interpreter.LineCommand;
+import ts.eclipse.ide.terminal.interpreter.TerminalCommandAdapter;
 import ts.eclipse.ide.ui.utils.StatusUtil;
+import ts.eclipse.ide.ui.widgets.NpmInstallWidget;
 import ts.eclipse.ide.ui.wizards.AbstractWizardNewTypeScriptProjectCreationPage;
 
 /**
@@ -35,13 +61,132 @@ public class WizardNewNgProjectCreationPage extends AbstractWizardNewTypeScriptP
 		"app"
 	};
 
+	// Angular CLI
+	private Boolean hasGlobalAngularCLI;
+	private Button useGlobalAngularCLIButton;
+	private Button useInstallAngularCLIButton;
+	private Text globalAngularCLIVersion;
+	private NpmInstallWidget installAngularCLI;
+	private boolean useGlobalAngularCLI;
+
+	private NgVersionJob ngVersionJob;
+
 	public WizardNewNgProjectCreationPage(String pageName, BasicNewResourceWizard wizard) {
 		super(pageName, wizard);
 	}
 
 	@Override
+	protected void createPageBody(Composite parent) {
+		super.createPageBody(parent);
+		Group group = new Group(parent, SWT.NONE);
+		group.setFont(parent.getFont());
+		group.setText(AngularCLIMessages.WizardNewNgProjectCreationPage_angular_cli_group_label);
+		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		int nColumns = 2;
+		GridLayout layout = new GridLayout();
+		layout.numColumns = nColumns;
+		group.setLayout(layout);
+
+		// Global Angular CLI
+		createGlobalAngularCLIField(group);
+
+		// Install Angular CLI
+		createInstallAngularCLIField(group);
+	}
+
+	/** Creates the field for install Angular CLI. */
+	private void createGlobalAngularCLIField(Composite parent) {
+		useGlobalAngularCLIButton = new Button(parent, SWT.RADIO);
+		useGlobalAngularCLIButton
+		.setText(AngularCLIMessages.WizardNewNgProjectCreationPage_useGlobalAngularCLI);
+		useGlobalAngularCLIButton.addListener(SWT.Selection, this);
+		useGlobalAngularCLIButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				updateAngularCLIMode();
+			}
+		});
+		globalAngularCLIVersion = new Text(parent, SWT.WRAP | SWT.READ_ONLY);
+		globalAngularCLIVersion.setText(""); //$NON-NLS-1$
+	}
+
+	/** Creates the field for install Angular CLI. */
+	private void createInstallAngularCLIField(Composite parent) {
+		useInstallAngularCLIButton = new Button(parent, SWT.RADIO);
+		useInstallAngularCLIButton
+				.setText(AngularCLIMessages.WizardNewNgProjectCreationPage_useInstallAngularCLI);
+		useInstallAngularCLIButton.addListener(SWT.Selection, this);
+		useInstallAngularCLIButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				updateAngularCLIMode();
+			}
+		});
+		installAngularCLI = new NpmInstallWidget("@angular/cli", this, parent, SWT.NONE);
+		installAngularCLI.getVersionText().addListener(SWT.Modify, this);
+	}
+
+	@Override
+	protected void initializeDefaultValues() {
+		super.initializeDefaultValues();
+		useGlobalAngularCLIButton.setSelection(true);
+	}
+
+	@Override
+	protected void nodeJsChanged(File nodeFile) {
+		super.nodeJsChanged(nodeFile);
+		if (hasGlobalAngularCLI == null && nodeFile != null && ngVersionJob == null) {
+			ngVersionJob = new NgVersionJob();
+			ngVersionJob.setNodeFile(nodeFile);
+			ngVersionJob.setNgFile(CLIProcessHelper.findNg());
+			ngVersionJob.addJobChangeListener(new JobChangeAdapter() {
+				@Override
+				public void done(IJobChangeEvent event) {
+					super.done(event);
+					IStatus status = event.getResult();
+					final String version;
+					if (status instanceof CLIStatus) {
+						final CLIStatus s = (CLIStatus) status;
+						version = s.getVersion();
+						if (s.isOK())
+							hasGlobalAngularCLI = Boolean.TRUE;
+					}
+					else {
+						hasGlobalAngularCLI = Boolean.FALSE;
+						version = "";
+					}
+					Display.getDefault().asyncExec(new Runnable() {
+						@Override
+						public void run() {
+							if (!globalAngularCLIVersion.isDisposed())
+								globalAngularCLIVersion.setText(version);
+							validatePage();
+						}
+					});
+				}
+			});
+			ngVersionJob.schedule();
+		}
+	}
+
+	@Override
+	protected void updateComponents(Event event) {
+		super.updateComponents(event);
+		Widget item = event != null ? event.item : null;
+		if (item == null || item == useGlobalAngularCLIButton)
+			updateAngularCLIMode();
+	}
+
+	private void updateAngularCLIMode() {
+		useGlobalAngularCLI = useGlobalAngularCLIButton.getSelection();
+		installAngularCLI.setEnabled(!useGlobalAngularCLI);
+	}
+
+	@Override
 	protected IStatus validatePageImpl() {
-		return StatusUtil.getMoreSevere(super.validatePageImpl(), validateNgProjectName(getProjectName()));
+		IStatus status = StatusUtil.getMoreSevere(super.validatePageImpl(), validateNgProjectName(getProjectName()));
+		return StatusUtil.getMoreSevere(status, validateAngularCLI());
 	}
 
 	/** Validates the name of the Angular-CLI Project. */
@@ -65,6 +210,47 @@ public class WizardNewNgProjectCreationPage extends AbstractWizardNewTypeScriptP
 			}
 		}
 		return status;
+	}
+
+	/** Validates the Angular CLI. */
+	private IStatus validateAngularCLI() {
+		if (useGlobalAngularCLI) {
+			if (hasGlobalAngularCLI == null)
+				return new Status(IStatus.ERROR, AngularCLIPlugin.PLUGIN_ID, AngularCLIMessages.WizardNewNgProjectCreationPage_searchingForGlobalAngularCLI);
+			else if (!hasGlobalAngularCLI.booleanValue())
+				return new Status(IStatus.ERROR, AngularCLIPlugin.PLUGIN_ID, AngularCLIMessages.WizardNewNgProjectCreationPage_noGlobalAngularCLI);
+			else
+				return Status.OK_STATUS;
+		}
+		return installAngularCLI.getStatus();
+	}
+
+	@Override
+	public void updateCommand(List<LineCommand> commands, final IEclipsePreferences preferences) {
+		if (!useGlobalAngularCLI) {
+			// when Angular CLI is installed, update the project Eclipse preferences
+			// to consume this installed Angular CLI.
+			commands.add(new LineCommand(installAngularCLI.getNpmInstallCommand(), new TerminalCommandAdapter() {
+				@Override
+				public void onTerminateCommand(LineCommand lineCommand) {
+
+					Display.getDefault().asyncExec(new Runnable() {
+						@Override
+						public void run() {
+							preferences.putBoolean(AngularCLIPreferenceConstants.NG_USE_GLOBAL_INSTALLATION, false);
+							preferences.put(AngularCLIPreferenceConstants.NG_CUSTOM_FILE_PATH,
+									"${project_loc:node_modules/.bin}");
+							try {
+								preferences.flush();
+							} catch (BackingStoreException e) {
+								e.printStackTrace();
+							}
+						}
+					});
+
+				}
+			}));
+		}
 	}
 
 }


### PR DESCRIPTION
see angelozerr/angular2-eclipse#74

- Add `NpmInstallWidget` for `@angular/cli` inside `WizardNewNgProjectCreationPage`.
- Moved `CLIStatus` and `NgVersionJob` into own files, to make them reusable.
- The project is now created immediately
- Following commands are now eexcuted when finishing Project wizard:
  - `npm install @angular/cli` (Optional)
  - `SET PATH=` or "export PATH=" (Optional)
  - `ng new`

This PR needs angelozerr/typescript.java#185 to be merged first, since it uses the new API.