### PR TITLE
Changed AngularCLI Global preferences and CLI setting in Angular Proj…

### DIFF
--- a/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/AngularCLIMessages.java
+++ b/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/AngularCLIMessages.java
@@ -58,10 +58,10 @@ public class AngularCLIMessages extends NLS {
 	public static String NewAngularProjectWizard_unsupportedProjectNames;
 
 	public static String WizardNewNgProjectCreationPage_angular_cli_group_label;
-	public static String WizardNewNgProjectCreationPage_useGlobalAngularCLI;
+	public static String WizardNewNgProjectCreationPage_useGlobalPreferencesCLI;
 	public static String WizardNewNgProjectCreationPage_useInstallAngularCLI;
-	public static String WizardNewNgProjectCreationPage_searchingForGlobalAngularCLI;
-	public static String WizardNewNgProjectCreationPage_noGlobalAngularCLI;
+	public static String WizardNewNgProjectCreationPage_searchingForGlobalPreferencesCLI;
+	public static String WizardNewNgProjectCreationPage_noGlobalPreferencesCLI;
 
 	public static String NewAngularProjectParamsWizardPage_title;
 	public static String NewAngularProjectParamsWizardPage_prefix;

--- a/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/AngularCLIMessages.properties
+++ b/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/AngularCLIMessages.properties
@@ -46,10 +46,10 @@ NewAngularProjectWizard_invalidProjectName=Project name "{0}" is not valid. New 
 NewAngularProjectWizard_unsupportedProjectNames=Project name "{0}" is not a supported name.
 
 WizardNewNgProjectCreationPage_angular_cli_group_label=Angular CLI
-WizardNewNgProjectCreationPage_useGlobalAngularCLI=Use global
+WizardNewNgProjectCreationPage_useGlobalPreferencesCLI=Use global preferences
 WizardNewNgProjectCreationPage_useInstallAngularCLI=Install
-WizardNewNgProjectCreationPage_searchingForGlobalAngularCLI=Searching for global Angular CLI...
-WizardNewNgProjectCreationPage_noGlobalAngularCLI=No global Angular CLI installation found.
+WizardNewNgProjectCreationPage_searchingForGlobalPreferencesCLI=Searching for global Angular CLI in global preferences...
+WizardNewNgProjectCreationPage_noGlobalPreferencesCLI=No Angular CLI installation found in global preferences.
 
 NewAngularProjectParamsWizardPage_title=Optional Params
 NewAngularProjectParamsWizardPage_prefix=&Prefix:


### PR DESCRIPTION
…ect-Wizard

See angelozerr/angular-eclipse#107 and angelozerr/angular-eclipse#94

In the global preferences, only the value "use global cli" is now validated.
The custom values won't be validated, since you often install only a project-private cli.  

In the Angular Project-Wizard you can now choose to use global cli preferences, instead of a globally installed cli.